### PR TITLE
move the check on hardware class into the load_hardware.

### DIFF
--- a/pulse_lib/base_pulse.py
+++ b/pulse_lib/base_pulse.py
@@ -10,11 +10,6 @@ from pulse_lib.configuration.devices import awg_slave
 from pulse_lib.virtual_matrix.virtual_gate_matrices import VirtualGateMatrices
 
 
-try:
-    from core_tools.drivers.hardware.hardware import hardware as hw_cls
-except:
-    print('old version of core_tools detected ..')
-
 class pulselib:
     '''
     Global class that is an organisational element in making the pulses.
@@ -397,6 +392,11 @@ class pulselib:
         Args:
             hardware (harware_parent) : harware class.
         '''
+        try:
+            from core_tools.drivers.hardware.hardware import hardware as hw_cls
+        except:
+            logging.warning('old version of core_tools detected ..')
+
         try:
             new_hardware_class = isinstance(hardware, hw_cls)
         except:


### PR DESCRIPTION
Can the check on hardware be moved into the load_hardware function? This way the pulse lib can be used independently of core_tools (without getting the print statement every time). I'm not entirely sure about my proposed implementation, maybe this try-except can be merged/omitted with the other one in the load_hardware, but I'm not completely sure which/how many hardware versions there are that should be kept compatible. 