### PR TITLE
Index selection on non-square virtual/combi gate matrices

### DIFF
--- a/pulse_lib/virtual_matrix/virtual_gate_matrix.py
+++ b/pulse_lib/virtual_matrix/virtual_gate_matrix.py
@@ -47,8 +47,8 @@ class VirtualGateMatrix:
         if self._invert:
             matrix = np.linalg.inv(matrix)
         if self._valid_indices:
-            matrix = matrix[:,self._valid_indices]
+            matrix = matrix[self._valid_indices, :]
             if self._square:
-                matrix = matrix[self._valid_indices]
+                matrix = matrix[:, self._valid_indices]
         return matrix
 


### PR DESCRIPTION
Hi @sldesnoo-Delft,

I believe the dimensions of the index selection (if non-rf gates exist in the virtual gate matrix), are flipped. This shows up when the matrix is not square (otherwise you won't notice).

Cheers!