### PR TITLE
Add API for IQ channel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name="pulse_lib",
             ],
     license='MIT',
     package_data={
+        "pulse_lib": ["py.typed"],
         "pulse_lib.tests.keysight_data": ["*.hdf5"],
         },
 	)


### PR DESCRIPTION
This is how I have done it now for lls. Still based on the IQ_channel_constructor to keep the implementation identical, but maybe a new/double implementation is preferred (to avoid circular dependencies). 

Also the name `define_iq_channel` looks a lot like `define_IQ_channel` but I could not think of something better and eventually the latter should be removed, I think.

Also added py.typed so that the typehints that exist at least are available to external users. 